### PR TITLE
FEATURE: Optimize Sidekiq settings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem 'pg', '~> 1.1'
 gem 'puma', '~> 5.0'
 gem 'rspotify', git: 'https://github.com/m-gizzi/rspotify.git'
 gem 'sidekiq', '~> 6.5.7'
+gem 'sidekiq-limit_fetch', '~> 4.3.2'
 gem 'sidekiq-scheduler', '~> 4.0.3'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,9 @@ GEM
       connection_pool (>= 2.2.5)
       rack (~> 2.0)
       redis (>= 4.5.0, < 5)
+    sidekiq-limit_fetch (4.3.2)
+      redis (>= 4.6.0)
+      sidekiq (>= 4)
     sidekiq-scheduler (4.0.3)
       redis (>= 4.2.0)
       rufus-scheduler (~> 3.2)
@@ -390,6 +393,7 @@ DEPENDENCIES
   rubocop-rspec (~> 2.12.1)
   selenium-webdriver
   sidekiq (~> 6.5.7)
+  sidekiq-limit_fetch (~> 4.3.2)
   sidekiq-scheduler (~> 4.0.3)
   simplecov
   sprockets-rails

--- a/app/sidekiq/update_artist_fallback_genres_job.rb
+++ b/app/sidekiq/update_artist_fallback_genres_job.rb
@@ -2,6 +2,7 @@
 
 class UpdateArtistFallbackGenresJob
   include Sidekiq::Job
+  sidekiq_options queue: :low_rate_spotify_api_calls
 
   def perform(artist_id)
     artist = Artist.find_by(id: artist_id)

--- a/app/sidekiq/update_artists_genres_job.rb
+++ b/app/sidekiq/update_artists_genres_job.rb
@@ -2,6 +2,7 @@
 
 class UpdateArtistsGenresJob
   include Sidekiq::Job
+  sidekiq_options queue: :spotify_api_calls
 
   def perform(artist_ids)
     artists = Artist.where(id: artist_ids)

--- a/app/sidekiq/update_playlist_track_data_batch_queuing_job.rb
+++ b/app/sidekiq/update_playlist_track_data_batch_queuing_job.rb
@@ -2,6 +2,7 @@
 
 class UpdatePlaylistTrackDataBatchQueuingJob
   include Sidekiq::Job
+  sidekiq_options queue: :spotify_api_calls
 
   def perform(playlist_id, playlist_class)
     playlist = playlist_class.constantize.find_by(id: playlist_id)

--- a/app/sidekiq/update_playlist_track_data_job.rb
+++ b/app/sidekiq/update_playlist_track_data_job.rb
@@ -2,6 +2,7 @@
 
 class UpdatePlaylistTrackDataJob
   include Sidekiq::Job
+  sidekiq_options queue: :spotify_api_calls
 
   def perform(playlist_id, playlist_class, track_data_id, offset = 0)
     playlist = playlist_class.constantize.find_by(id: playlist_id)

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,3 +10,10 @@
   BatchUpdateArtistsFallbackGenresJob:
     # Every day at 2:00am CST
     cron: '0 7 * * *'
+
+:queues:
+  - [default, 1]
+  - [low_rate_spotify_api_calls, 1]
+
+:process_limits:
+  low_rate_spotify_api_calls: 2

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,6 +13,7 @@
 
 :queues:
   - [default, 1]
+  - [spotify_api_calls, 1]
   - [low_rate_spotify_api_calls, 1]
 
 :process_limits:

--- a/fly.toml
+++ b/fly.toml
@@ -24,7 +24,7 @@ kill_timeout = 5
 
 [processes]
   web = "bin/rails fly:server"
-  worker = "bundle exec sidekiq -c 2"
+  worker = "bundle exec sidekiq -c 3"
 
 [[services]]
   http_checks = []

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -49,12 +49,21 @@ class SpotifyClient
     yield
   rescue *rescued_exception_classes => e
     Bugsnag.notify(e)
-    sleep(seconds_to_retry_after(e))
+    @error = e
+    sleep(seconds_to_retry_after)
     retry
   end
 
-  def seconds_to_retry_after(error)
+  def seconds_to_retry_after
+    error_retry_after_header.to_i
+  end
+
+  def error_retry_after_header
     # Spotify returns a header that tells you the number of seconds to wait before trying again
-    error.http_headers[:retry_after].to_i
+    error.http_headers[:retry_after]
+  end
+
+  def spotify_api_queue
+    Sidekiq::Queue['low_rate_spotify_api_calls']
   end
 end

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -48,8 +48,10 @@ class SpotifyClient
   def handle_retryable_error(rescued_exception_classes)
     yield
   rescue *rescued_exception_classes => e
-    Bugsnag.notify(e)
     @error = e
+    Bugsnag.notify(@error) do |event|
+      event.add_metadata(:diagnostics, { headers: @error.http_headers })
+    end
     sleep(seconds_to_retry_after)
     retry
   end

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -54,7 +54,7 @@ class SpotifyClient
     yield
   rescue *rescued_exception_classes => e
     @error = e
-    # pause_queues
+    pause_queues
     log_error
     sleep(seconds_to_retry_after)
     retry
@@ -69,9 +69,9 @@ class SpotifyClient
     @error.http_headers[:retry_after]
   end
 
-  # def pause_queues
-  #   SPOTIFY_SIDEKIQ_QUEUES.each { |queue| queue.pause_for_ms(seconds_to_retry_after * 1000) }
-  # end
+  def pause_queues
+    SPOTIFY_SIDEKIQ_QUEUES.each { |queue| queue.pause_for_ms(seconds_to_retry_after * 1000) }
+  end
 
   def log_error
     Bugsnag.notify(@error) { |event| event.add_metadata(:diagnostics, { headers: @error.http_headers }) }

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -54,7 +54,7 @@ class SpotifyClient
     yield
   rescue *rescued_exception_classes => e
     @error = e
-    pause_queues
+    # pause_queues
     log_error
     sleep(seconds_to_retry_after)
     retry
@@ -69,9 +69,9 @@ class SpotifyClient
     @error.http_headers[:retry_after]
   end
 
-  def pause_queues
-    SPOTIFY_SIDEKIQ_QUEUES.each { |queue| queue.pause_for_ms(seconds_to_retry_after * 1000) }
-  end
+  # def pause_queues
+  #   SPOTIFY_SIDEKIQ_QUEUES.each { |queue| queue.pause_for_ms(seconds_to_retry_after * 1000) }
+  # end
 
   def log_error
     Bugsnag.notify(@error) { |event| event.add_metadata(:diagnostics, { headers: @error.http_headers }) }

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -62,7 +62,7 @@ class SpotifyClient
 
   def error_retry_after_header
     # Spotify returns a header that tells you the number of seconds to wait before trying again
-    error.http_headers[:retry_after]
+    @error.http_headers[:retry_after]
   end
 
   def spotify_api_queue

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -3,13 +3,15 @@
 require 'responses/response'
 
 class SpotifyClient
+  attr_accessor :exception
+
   SPOTIFY_SIDEKIQ_QUEUES = [
     Sidekiq::Queue['spotify_api_calls'],
     Sidekiq::Queue['low_rate_spotify_api_calls']
   ].freeze
 
   def get_playlist_by_id(playlist_id)
-    handle_retryable_error(RestClient::TooManyRequests) do
+    handle_too_many_requests_error do
       # rubocop:disable Rails/DynamicFindBy
       RSpotify::Playlist.find_by_id(playlist_id)
       # rubocop:enable Rails/DynamicFindBy
@@ -22,26 +24,26 @@ class SpotifyClient
       raise ArgumentError, "#{__method__} cannot accept more than #{MAXIMUM_ARTIST_LOOKUPS_PER_CALL} ids as arguments"
     end
 
-    handle_retryable_error(RestClient::TooManyRequests) do
+    handle_too_many_requests_error do
       RSpotify::Artist.find(artist_ids)
     end
   end
 
   def get_related_artists(rspotify_artist)
-    handle_retryable_error(RestClient::TooManyRequests) do
+    handle_too_many_requests_error do
       rspotify_artist.related_artists
     end
   end
 
   def get_tracks(rspotify_playlist, offset: 0)
-    handle_retryable_error(RestClient::TooManyRequests) do
+    handle_too_many_requests_error do
       raw_response = rspotify_playlist.tracks(raw_response: true, offset:)
       Responses::GetTracks.new(raw_response)
     end
   end
 
   def get_liked_tracks(rspotify_user, offset: 0)
-    handle_retryable_error(RestClient::TooManyRequests) do
+    handle_too_many_requests_error do
       # RSpotify::User.saved_tracks has a maximum limit of 50 tracks returned
       raw_response = rspotify_user.saved_tracks(raw_response: true, limit: 50, offset:)
       Responses::GetTracks.new(raw_response)
@@ -50,10 +52,10 @@ class SpotifyClient
 
   private
 
-  def handle_retryable_error(rescued_exception_classes)
+  def handle_too_many_requests_error
     yield
-  rescue *rescued_exception_classes => e
-    @error = e
+  rescue RestClient::TooManyRequests => e
+    self.exception = e
     pause_queues
     log_error
     sleep(seconds_to_retry_after)
@@ -66,7 +68,7 @@ class SpotifyClient
 
   def error_retry_after_header
     # Spotify returns a header that tells you the number of seconds to wait before trying again
-    @error.http_headers[:retry_after]
+    exception.http_headers[:retry_after]
   end
 
   def pause_queues
@@ -74,6 +76,6 @@ class SpotifyClient
   end
 
   def log_error
-    Bugsnag.notify(@error) { |event| event.add_metadata(:diagnostics, { headers: @error.http_headers }) }
+    Bugsnag.notify(exception) { |event| event.add_metadata(:diagnostics, { headers: exception.http_headers }) }
   end
 end

--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -61,7 +61,7 @@ class SpotifyClient
   end
 
   def seconds_to_retry_after
-    error_retry_after_header.to_i
+    error_retry_after_header.to_i + 1
   end
 
   def error_retry_after_header


### PR DESCRIPTION
# Description
- Set Sidekiq concurrency to 3
- Create a low rate alternative queue with a concurrency of 2
- Add additional diagnostic information to Bugsnag reporting
- Extend length of pause before retrying TooManyRequest errors
- Pause all Spotify API queues temporarily if rate limit is exceeded