### PR TITLE
FEATURE: Expand Artist scopes and allow multiple genres to be passed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,7 @@ RSpec/NestedGroups:
 
 RSpec/MultipleMemoizedHelpers:
   Max: 7
+
+RSpec/LetSetup:
+  Exclude:
+    - 'spec/models/artist_spec.rb'

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -19,14 +19,14 @@ class Artist < ApplicationRecord
   scope :matching_any_genres, ->(genres) { left_joins(:genres).where(genres: { name: genres }).distinct }
   scope :not_matching_any_genres, ->(genres) { where.not(id: matching_any_genres(genres)) }
 
-  validates :name, presence: true
-  validates :spotify_id, presence: { message: I18n.t('active_record_validations.spotify_id.presence') },
-                         uniqueness: { message: I18n.t('active_record_validations.spotify_id.uniqueness') }
-
   class << self
     alias in_genre matching_any_genres
     alias not_in_genre not_matching_any_genres
   end
+
+  validates :name, presence: true
+  validates :spotify_id, presence: { message: I18n.t('active_record_validations.spotify_id.presence') },
+                         uniqueness: { message: I18n.t('active_record_validations.spotify_id.uniqueness') }
 
   def self.matching_all_genres(genres)
     unless genres.is_a?(Array)

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -17,17 +17,29 @@ class Artist < ApplicationRecord
   has_many :fallback_genres, through: :artists_fallback_genres, source: :genre
 
   scope :matching_any_genres, ->(genres) { left_joins(:genres).where(genres: { name: genres }).distinct }
-  scope :not_matching_any_genres, ->(genres) { where.not(id: in_any_genres(genres)) }
-  scope :matching_all_genres, lambda { |genres|
-    first_query = in_any_genres(genres.shift).ids
-    ids = genres.reduce(first_query) { |queries, genre| queries & in_any_genres(genre).ids }
-    where(id: ids)
-  }
-  scope :not_matching_all_genres, ->(genres) { where.not(id: in_all_genres(genres)) }
+  scope :not_matching_any_genres, ->(genres) { where.not(id: matching_any_genres(genres)) }
 
   validates :name, presence: true
   validates :spotify_id, presence: { message: I18n.t('active_record_validations.spotify_id.presence') },
                          uniqueness: { message: I18n.t('active_record_validations.spotify_id.uniqueness') }
+
+  def self.matching_all_genres(genres)
+    unless genres.is_a?(Array)
+      raise 'Use logically equivalent .matching_any_genres if only passing a single string as an argument.'
+    end
+
+    first_query = matching_any_genres(genres.shift).ids
+    ids = genres.reduce(first_query) { |queries, genre| queries & matching_any_genres(genre).ids }
+    where(id: ids)
+  end
+
+  def self.not_matching_all_genres(genres)
+    unless genres.is_a?(Array)
+      raise 'Use logically equivalent .not_matching_any_genres if only passing a single string as an argument.'
+    end
+
+    where.not(id: matching_all_genres(genres))
+  end
 
   def to_rspotify_artist
     spotify_client.get_artists_by_ids([spotify_id]).first

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -23,6 +23,11 @@ class Artist < ApplicationRecord
   validates :spotify_id, presence: { message: I18n.t('active_record_validations.spotify_id.presence') },
                          uniqueness: { message: I18n.t('active_record_validations.spotify_id.uniqueness') }
 
+  class << self
+    alias in_genre matching_any_genres
+    alias not_in_genre not_matching_any_genres
+  end
+
   def self.matching_all_genres(genres)
     unless genres.is_a?(Array)
       raise 'Use logically equivalent .matching_any_genres if only passing a single string as an argument.'

--- a/app/models/track.rb
+++ b/app/models/track.rb
@@ -13,7 +13,7 @@ class Track < ApplicationRecord
     left_joins(:genres).where(genres: { name: genre }).distinct
   }
   scope :with_at_least_one_artist_not_in_genre, lambda { |genre|
-    joins(:artists).where(artists: Artist.not_in_genre(genre)).distinct
+    joins(:artists).where(artists: Artist.not_matching_any_genres(genre)).distinct
   }
   scope :with_all_artists_in_genre, ->(genre) { where.not(id: Track.with_at_least_one_artist_not_in_genre(genre)) }
 end

--- a/app/sidekiq/batch_update_artists_fallback_genres_job.rb
+++ b/app/sidekiq/batch_update_artists_fallback_genres_job.rb
@@ -4,7 +4,7 @@ class BatchUpdateArtistsFallbackGenresJob
   include Sidekiq::Job
 
   def perform
-    args = Artist.matching_any_genres(nil).ids.zip
+    args = Artist.in_genre(nil).ids.zip
     UpdateArtistFallbackGenresJob.perform_bulk(args)
   end
 end

--- a/app/sidekiq/batch_update_artists_fallback_genres_job.rb
+++ b/app/sidekiq/batch_update_artists_fallback_genres_job.rb
@@ -4,7 +4,7 @@ class BatchUpdateArtistsFallbackGenresJob
   include Sidekiq::Job
 
   def perform
-    args = Artist.in_genre(nil).ids.zip
+    args = Artist.matching_any_genres(nil).ids.zip
     UpdateArtistFallbackGenresJob.perform_bulk(args)
   end
 end


### PR DESCRIPTION
# Description
- [x] In order to allow passing multiple genres to a scope at once, refactor Artist scopes into 4 different scopes